### PR TITLE
Fix pytorch conversion to a valid number

### DIFF
--- a/pytorch/mnist/train.py
+++ b/pytorch/mnist/train.py
@@ -80,4 +80,4 @@ def test(model, test_loader, cuda):
             len(test_loader.dataset),
             100. * accuracy)
     )
-    send_metrics(loss=test_loss, accuracy=accuracy)
+    send_metrics(loss=test_loss.item(), accuracy=accuracy.item())


### PR DESCRIPTION
I assume this changed in pytorch 1.0 or newer versions. without this you get: https://github.com/polyaxon/polyaxon-helper/issues/2