### PR TITLE
Fix Keras examples

### DIFF
--- a/in_cluster/keras/cnn_lstm/polyaxonfile.yml
+++ b/in_cluster/keras/cnn_lstm/polyaxonfile.yml
@@ -3,7 +3,6 @@ kind: component
 tags: [examples, keras]
 
 inputs:
-- {name: image, type: str}
 - {name: max_features, type: int, value: 20000, isOptional: true}
 - {name: skip_top, type: int, value: 50, isOptional: true}
 - {name: maxlen, type: int, value: 100, isOptional: true}

--- a/in_cluster/keras/mnist/polyaxonfile.yml
+++ b/in_cluster/keras/mnist/polyaxonfile.yml
@@ -3,7 +3,6 @@ kind: component
 tags: [examples, keras]
 
 inputs:
-- {name: image, type: str}
 - {name: conv1_size, type: int, value: 32, isOptional: true}
 - {name: conv2_size, type: int, value: 64, isOptional: true}
 - {name: dropout, type: float, value: 0.8, isOptional: true}


### PR DESCRIPTION
The yaml files declare `image` as a required input but it is never used in the file. This PR removes the unnecessary value.