### PR TITLE
Update polyaxon_hyperparams.yml

### DIFF
--- a/in_cluster/sklearn/newsgroup/polyaxon_hyperparams.yml
+++ b/in_cluster/sklearn/newsgroup/polyaxon_hyperparams.yml
@@ -16,5 +16,5 @@ matrix:
       value: [1.0, 0.5, 0.1, 0.01]
     max_df:
       kind: choice
-      value: 0.5, 0.75, 1.0]
+      value: [0.5, 0.75, 1.0]
 pathRef: ./polyaxonfile.yml


### PR DESCRIPTION
polyaxon check fails with the current yaml due to a typo

```
$ polyaxon check -f polyaxon_hyperparams.yml 
Polyaxonfile is not valid.
Error message: {'matrix': {0: {'params': defaultdict(<class 'dict'>, {'max_df': {'value': {0: {'value': ['Not a valid list.']}}}})}}}.
```